### PR TITLE
Call these functions internal

### DIFF
--- a/src/Rules/NoPrivate/CallToPrivateFunctionRule.php
+++ b/src/Rules/NoPrivate/CallToPrivateFunctionRule.php
@@ -66,7 +66,7 @@ class CallToPrivateFunctionRule implements Rule
 		}
 
 		return [sprintf(
-			'Call to private function %s().',
+			'Call to internal function %s().',
 			$function->getName()
 		)];
 	}


### PR DESCRIPTION
PHP has more than one meaning for "private".
`@access private` functions are really internal WordPress core functions.
