### PR TITLE
Do not report (actual) private methods within the same class

### DIFF
--- a/src/Rules/NoPrivate/CallToPrivateMethodRule.php
+++ b/src/Rules/NoPrivate/CallToPrivateMethodRule.php
@@ -51,6 +51,10 @@ class CallToPrivateMethodRule implements Rule
 				$classReflection = $this->reflectionProvider->getClass($referencedClass);
 				$methodReflection = $classReflection->getMethod($methodName, $scope);
 
+				if ($methodReflection->isPrivate()) {
+					continue;
+				}
+
 				$docComment = $methodReflection->getDocComment();
 
 				if (!$docComment) {
@@ -66,6 +70,14 @@ class CallToPrivateMethodRule implements Rule
 				);
 
 				if (!PrivateAnnotationHelper::isPrivate($resolvedPhpDoc)) {
+					continue;
+				}
+
+
+				if (
+					$scope->isInClass() &&
+					$classReflection->getName() === $methodReflection->getDeclaringClass()->getName()
+				) {
 					continue;
 				}
 

--- a/src/Rules/NoPrivate/CallToPrivateStaticMethodRule.php
+++ b/src/Rules/NoPrivate/CallToPrivateStaticMethodRule.php
@@ -84,6 +84,10 @@ class CallToPrivateStaticMethodRule implements Rule
 				continue;
 			}
 
+			if ($methodReflection->isPrivate()) {
+				continue;
+			}
+
 			$resolvedPhpDoc = $class->getResolvedPhpDoc();
 			if ($resolvedPhpDoc && PrivateAnnotationHelper::isPrivate($resolvedPhpDoc)) {
 				$errors[] = sprintf(
@@ -107,7 +111,16 @@ class CallToPrivateStaticMethodRule implements Rule
 				$methodReflection->getName(),
 				$docComment
 			);
+
 			if (!PrivateAnnotationHelper::isPrivate($resolvedPhpDoc)) {
+				continue;
+			}
+
+			if (
+				$scope->isInClass() &&
+				$class->getName() === $methodReflection->getDeclaringClass()->getName() &&
+				$class->getName() === $scope->getClassReflection()->getName()
+			) {
 				continue;
 			}
 

--- a/tests/Rules/NoPrivate/CallToPrivateStaticMethodRuleTest.php
+++ b/tests/Rules/NoPrivate/CallToPrivateStaticMethodRuleTest.php
@@ -49,16 +49,8 @@ class CallToPrivateStaticMethodRuleTest extends RuleTestCase
 					44,
 				],
 				[
-					'Call to private/internal method privateOtherFoo() of class CheckPrivateStaticMethodCall\Child.',
-					45,
-				],
-				[
 					'Call to private/internal method privateFoo() of class CheckPrivateStaticMethodCall\Foo.',
 					46,
-				],
-				[
-					'Call to private/internal method privateOtherFoo() of class CheckPrivateStaticMethodCall\Child.',
-					47,
 				],
 			]
 		);

--- a/tests/Rules/NoPrivate/data/call-to-private-method-definition.php
+++ b/tests/Rules/NoPrivate/data/call-to-private-method-definition.php
@@ -17,4 +17,11 @@ class Foo
 	{
 
 	}
+	/**
+	 * @access private
+	 */
+	private function reallyPrivateFoo()
+	{
+
+	}
 }

--- a/tests/Rules/NoPrivate/data/call-to-private-method.php
+++ b/tests/Rules/NoPrivate/data/call-to-private-method.php
@@ -5,3 +5,38 @@ namespace CheckPrivateMethodCall;
 $foo = new Foo();
 $foo->foo();
 $foo->privateFoo();
+
+class Bar
+{
+
+	public function publicBar()
+	{
+		$this->privateBar();
+		$this->reallyPrivateBar();
+	}
+
+	/**
+	 * @access private
+	 */
+	public function privateBar()
+	{
+
+	}
+
+	/**
+	 * @access private
+	 */
+	private function reallyPrivateBar()
+	{
+
+	}
+}
+
+class Baz extends Foo
+{
+
+	public function foo()
+	{
+		$this->privateFoo();
+	}
+}

--- a/tests/Rules/NoPrivate/data/call-to-private-static-method.php
+++ b/tests/Rules/NoPrivate/data/call-to-private-static-method.php
@@ -47,3 +47,29 @@ class Child extends Foo
 		static::privateOtherFoo();
 	}
 }
+
+class Baz
+{
+
+	public static function publicBaz()
+	{
+		self::privateBaz();
+		self::reallyPrivateBaz();
+	}
+
+	/**
+	 * @access private
+	 */
+	public static function privateBaz()
+	{
+
+	}
+
+	/**
+	 * @access private
+	 */
+	private static function reallyPrivateBaz()
+	{
+
+	}
+}


### PR DESCRIPTION
- Ignore methods with actual private visibility due to redundancy.
- Do not flag method calls within the same class. A class is allowed to call its own private methods.

Fixes #1